### PR TITLE
Fix "'License :: OSI Approved :: ISC License' is not a valid classifier" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Overall code clean up and linting changes.
 ### Fixes
 Fix poetry 2.x "The option --no-update does not exist" error message [FA-84].
 Missing "context" and "event_dict" properties, "to_dict" and "to_original_event" events, were added to the FastAPI Request class.
+"'License :: OSI Approved :: ISC License' is not a valid classifier" error fixed [FA-84].
 
 
 ## 0.1.9 (2024-10-07)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     'Development Status :: 3 - Alpha',
     'Environment :: Console',
     'Intended Audience :: Developers',
-    "License :: OSI Approved :: ISC License",
     "Programming Language :: Python :: 3",
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ classifiers = [
     'Development Status :: 3 - Alpha',
     'Environment :: Console',
     'Intended Audience :: Developers',
-    'License-Expression :: ISC',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ classifiers = [
     'Development Status :: 3 - Alpha',
     'Environment :: Console',
     'Intended Audience :: Developers',
-    'License :: OSI Approved :: ISC License',
+    'License-Expression :: ISC',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
"'License :: OSI Approved :: ISC License' is not a valid classifier" error fixed [FA-84].

[FA-84]: https://mediabros.atlassian.net/browse/FA-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ